### PR TITLE
Fix TeleportPoint script mismatch

### DIFF
--- a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs
+++ b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs
@@ -1,0 +1,5 @@
+﻿using UnityEngine;
+
+public interface ITeleportPoint {
+    Transform DestinationTransform { get; }
+}

--- a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs.meta
+++ b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 28c427107d49435e8b60c3b9dd141a28
+timeCreated: 1667469084

--- a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportPoint.cs
+++ b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportPoint.cs
@@ -22,7 +22,7 @@
 using UnityEngine;
 using System.Collections;
 
-public class TeleportPoint : MonoBehaviour {
+public class TeleportPoint : MonoBehaviour, ITeleportPoint {
 
     public float dimmingSpeed = 1;
     public float fullIntensity = 1;
@@ -39,10 +39,7 @@ public class TeleportPoint : MonoBehaviour {
 
 	}
 
-    public Transform GetDestTransform()
-    {
-        return destTransform;
-    }
+    public Transform DestinationTransform => destTransform;
 
 
 

--- a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportTargetHandlerNode.cs
+++ b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportTargetHandlerNode.cs
@@ -38,7 +38,7 @@ public class TeleportTargetHandlerNode : TeleportTargetHandler
 		{
 			return false;
 		}
-		TeleportPoint tp = AimData.TargetHitInfo.collider.gameObject.GetComponent<TeleportPoint>();
+		ITeleportPoint tp = AimData.TargetHitInfo.collider.gameObject.GetComponent<ITeleportPoint>();
 		if (tp == null)
 		{
 			return false;
@@ -47,7 +47,7 @@ public class TeleportTargetHandlerNode : TeleportTargetHandler
 		// The targeting test discovered a valid teleport node. Now test to make sure there is line of sight to the 
 		// actual destination. Since the teleport destination is expected to be right on the ground, use the LOSOffset 
 		// to bump the collision check up off the ground a bit.
-		var dest = tp.destTransform.position;
+		var dest = tp.DestinationTransform.position;
 		var offsetEnd = new Vector3(dest.x, dest.y + LOSOffset, dest.z);
 		if (LocomotionTeleport.AimCollisionTest(start, offsetEnd, AimCollisionLayerMask & ~TeleportLayerMask, out AimData.TargetHitInfo))
 		{

--- a/ORST/Assets/Scripts/Core/Movement/Teleportation/AdvancedLocomotionTeleport.cs
+++ b/ORST/Assets/Scripts/Core/Movement/Teleportation/AdvancedLocomotionTeleport.cs
@@ -10,9 +10,6 @@ namespace ORST.Core.Movement {
         public event Action ExitedIntersection;
         public event Action<TeleportPointORST> TeleportedToPoint;
 
-        /// <summary>
-        /// Start the state machine coroutines.
-        /// </summary>
         public override void OnEnable() {
             base.OnEnable();
 
@@ -35,16 +32,12 @@ namespace ORST.Core.Movement {
         }
 
         private void OnTeleported(Transform controllerTransform, Vector3 position, Quaternion rotation) {
-            if (TargetHandler is not AdvancedTeleportTargetHandlerNode nodeHandler) {
+            if (TargetHandler is not AdvancedTeleportTargetHandlerNode {TargetPoint: { } targetPoint}) {
+                Debug.LogWarning("[Teleportation] Couldn't find target point when teleporting.");
                 return;
             }
 
-            if (nodeHandler.AimData.TargetHitInfo.collider == null ||
-                nodeHandler.AimData.TargetHitInfo.collider.GetComponent<TeleportPointORST>() is not {} teleportPoint) {
-                return;
-            }
-
-            TeleportedToPoint?.Invoke(teleportPoint);
+            TeleportedToPoint?.Invoke(targetPoint);
         }
     }
 }

--- a/ORST/Assets/Scripts/Core/Movement/Teleportation/AdvancedTeleportTargetHandlerNode.cs
+++ b/ORST/Assets/Scripts/Core/Movement/Teleportation/AdvancedTeleportTargetHandlerNode.cs
@@ -9,6 +9,7 @@ namespace ORST.Core.Movement {
         private bool m_IsIntersectChanged;
         private bool m_ValidCollisionOnSegment;
 
+        public TeleportPointORST TargetPoint { get; private set; }
         public new LocomotionTeleport.AimData AimData => base.AimData;
 
         protected override void OnEnable() {
@@ -34,6 +35,8 @@ namespace ORST.Core.Movement {
                 // With each targeting test, we need to reset the AimData to clear the point list and reset flags.
                 ResetAimData();
 
+                TargetPoint = null;
+
                 // Start the testing with the character's current position to the aiming origin to ensure they 
                 // haven't just stuck their hand through something that should have prevented movement.
                 //
@@ -46,6 +49,7 @@ namespace ORST.Core.Movement {
                 // stopping at the first valid target or when the enumerable runs out of line segments.
                 AimPoints.Clear();
                 LocomotionTeleport.AimHandler.GetPoints(AimPoints);
+
 
                 m_ValidCollisionOnSegment = false;
                 Vector3 segmentColliderPoint = Vector3.zero;
@@ -122,6 +126,7 @@ namespace ORST.Core.Movement {
             }
 
             end = destination;
+            TargetPoint = tp;
             return true;
         }
 

--- a/ORST/Assets/Scripts/Core/Movement/Teleportation/TeleportPointORST.cs
+++ b/ORST/Assets/Scripts/Core/Movement/Teleportation/TeleportPointORST.cs
@@ -3,7 +3,7 @@ using Sirenix.OdinInspector;
 using UnityEngine;
 
 namespace ORST.Core.Movement {
-    public class TeleportPointORST : BaseMonoBehaviour {
+    public class TeleportPointORST : BaseMonoBehaviour, ITeleportPoint {
         [SerializeField, Required] private Transform m_DestinationTransform;
 
         public Transform DestinationTransform => m_DestinationTransform;

--- a/ORST/Patches/Oculus/teleport_point_interface.patch
+++ b/ORST/Patches/Oculus/teleport_point_interface.patch
@@ -1,0 +1,69 @@
+diff --git a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs
+new file mode 100644
+index 0000000..1fb1b7d
+--- /dev/null
++++ b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs
+@@ -0,0 +1,5 @@
++﻿using UnityEngine;
++
++public interface ITeleportPoint {
++    Transform DestinationTransform { get; }
++}
+\ No newline at end of file
+diff --git a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs.meta b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs.meta
+new file mode 100644
+index 0000000..d779d06
+--- /dev/null
++++ b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/ITeleportPoint.cs.meta
+@@ -0,0 +1,3 @@
++﻿fileFormatVersion: 2
++guid: 28c427107d49435e8b60c3b9dd141a28
++timeCreated: 1667469084
+\ No newline at end of file
+diff --git a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportPoint.cs b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportPoint.cs
+index 69a4124..b3771dd 100644
+--- a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportPoint.cs
++++ b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportPoint.cs
+@@ -22,7 +22,7 @@
+ using UnityEngine;
+ using System.Collections;
+ 
+-public class TeleportPoint : MonoBehaviour {
++public class TeleportPoint : MonoBehaviour, ITeleportPoint {
+ 
+     public float dimmingSpeed = 1;
+     public float fullIntensity = 1;
+@@ -39,10 +39,7 @@ public class TeleportPoint : MonoBehaviour {
+ 
+ 	}
+ 
+-    public Transform GetDestTransform()
+-    {
+-        return destTransform;
+-    }
++    public Transform DestinationTransform => destTransform;
+ 
+ 
+ 
+diff --git a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportTargetHandlerNode.cs b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportTargetHandlerNode.cs
+index c8eb023..87f2fc3 100644
+--- a/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportTargetHandlerNode.cs
++++ b/ORST/Assets/Oculus/SampleFramework/Core/Locomotion/Scripts/TeleportTargetHandlerNode.cs
+@@ -38,7 +38,7 @@ protected override bool ConsiderTeleport(Vector3 start, ref Vector3 end)
+ 		{
+ 			return false;
+ 		}
+-		TeleportPoint tp = AimData.TargetHitInfo.collider.gameObject.GetComponent<TeleportPoint>();
++		ITeleportPoint tp = AimData.TargetHitInfo.collider.gameObject.GetComponent<ITeleportPoint>();
+ 		if (tp == null)
+ 		{
+ 			return false;
+@@ -47,7 +47,7 @@ protected override bool ConsiderTeleport(Vector3 start, ref Vector3 end)
+ 		// The targeting test discovered a valid teleport node. Now test to make sure there is line of sight to the 
+ 		// actual destination. Since the teleport destination is expected to be right on the ground, use the LOSOffset 
+ 		// to bump the collision check up off the ground a bit.
+-		var dest = tp.destTransform.position;
++		var dest = tp.DestinationTransform.position;
+ 		var offsetEnd = new Vector3(dest.x, dest.y + LOSOffset, dest.z);
+ 		if (LocomotionTeleport.AimCollisionTest(start, offsetEnd, AimCollisionLayerMask & ~TeleportLayerMask, out AimData.TargetHitInfo))
+ 		{


### PR DESCRIPTION
Currently in the implementation for teleportation we use both `TeleportPoint` and `TeleportPointORST` which leads to issues. 

This PR also reworks the logic for tracking the teleport point to which the player has just teleported and now correctly fires `TeleportedToPoint` events.

Fixes #18 