### PR TITLE
Implement common tasks

### DIFF
--- a/ORST/Assets/Scripts/Core/Dialogues/Demo/SampleDialogueHandler.cs
+++ b/ORST/Assets/Scripts/Core/Dialogues/Demo/SampleDialogueHandler.cs
@@ -50,14 +50,14 @@ namespace ORST.Core.Dialogues.Demo {
 
             Destroy(m_DialogueView.gameObject);
             m_DialogueView = null;
-            DialogueManager.EndDialogue();
+            DialogueManager.EndDialogue(true);
 
             m_FinishedInteractingWithUI = false;
             m_State = default;
         }
 
-        public void HandleDialogueEnded() {
-            Debug.Log("Dialogue ended");
+        public void HandleDialogueEnded(bool completed) {
+            Debug.Log($"Dialogue ended. Completed: {completed}");
         }
     }
 }

--- a/ORST/Assets/Scripts/Core/Dialogues/Demo/SampleDialogueTrigger.cs
+++ b/ORST/Assets/Scripts/Core/Dialogues/Demo/SampleDialogueTrigger.cs
@@ -12,7 +12,7 @@ namespace ORST.Core.Dialogues.Demo {
             DialogueManager.DialogueEnded -= OnDialogueEnded;
         }
 
-        private void OnDialogueEnded(Dialogue dialogue) {
+        private void OnDialogueEnded(Dialogue dialogue, bool completed) {
             if (dialogue == Dialogue) {
                 m_DialogueStarted = false;
             }

--- a/ORST/Assets/Scripts/Core/Dialogues/DialogueManager.cs
+++ b/ORST/Assets/Scripts/Core/Dialogues/DialogueManager.cs
@@ -23,7 +23,7 @@ namespace ORST.Core.Dialogues {
         /// <summary>
         /// Event called when a dialogue has ended.
         /// </summary>
-        public static event Action<Dialogue> DialogueEnded;
+        public static event Action<Dialogue, bool> DialogueEnded;
 
         /// <summary>
         /// Gets a reference to the active dialogue.
@@ -44,7 +44,7 @@ namespace ORST.Core.Dialogues {
         /// </summary>
         public static void StartDialogue(Dialogue dialogue) {
             if (Instance.m_ActiveDialogue != null) {
-                EndDialogue();
+                EndDialogue(false);
             }
 
             Instance.m_ActiveDialogueHandler = Instance.m_DialogueHandlerDictionary[dialogue];
@@ -57,13 +57,14 @@ namespace ORST.Core.Dialogues {
         /// <summary>
         /// End the current dialogue.
         /// </summary>
-        public static void EndDialogue() {
+        /// <param name="completed">Whether the dialogue was completed or not.</param>
+        public static void EndDialogue(bool completed) {
             if (Instance.m_ActiveDialogue == null) {
                 return;
             }
 
-            Instance.m_ActiveDialogueHandler.HandleDialogueEnded();
-            DialogueEnded?.Invoke(Instance.m_ActiveDialogue);
+            Instance.m_ActiveDialogueHandler.HandleDialogueEnded(completed);
+            DialogueEnded?.Invoke(Instance.m_ActiveDialogue, completed);
 
             Instance.m_ActiveDialogue = null;
             Instance.m_ActiveDialogueHandler = null;

--- a/ORST/Assets/Scripts/Core/Dialogues/Interfaces/IDialogueHandler.cs
+++ b/ORST/Assets/Scripts/Core/Dialogues/Interfaces/IDialogueHandler.cs
@@ -3,6 +3,6 @@
         Dialogue Dialogue { get; }
 
         void HandleDialogueStarted();
-        void HandleDialogueEnded();
+        void HandleDialogueEnded(bool completed);
     }
 }

--- a/ORST/Assets/Scripts/Core/Dialogues/Triggers/TeleportPointDialogueTrigger.cs
+++ b/ORST/Assets/Scripts/Core/Dialogues/Triggers/TeleportPointDialogueTrigger.cs
@@ -20,7 +20,9 @@ namespace ORST.Core.Dialogues {
         private void OnTeleportedToPoint(TeleportPointORST teleportPoint) {
             if (teleportPoint != m_TeleportPoint) {
                 if (ReferenceEquals(DialogueManager.ActiveDialogue, m_Dialogue)) {
-                    DialogueManager.EndDialogue();
+                    // If you teleport away while the dialogue is active then it will be considered
+                    // cancelled instead of completed.
+                    DialogueManager.EndDialogue(false);
                 }
 
                 return;

--- a/ORST/Assets/Scripts/Core/ModuleTasks/GeneralTasks/CompleteDialogueTask.cs
+++ b/ORST/Assets/Scripts/Core/ModuleTasks/GeneralTasks/CompleteDialogueTask.cs
@@ -1,0 +1,43 @@
+﻿using ORST.Core.Dialogues;
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+namespace ORST.Core.ModuleTasks {
+    public class CompleteDialogueTask : ModuleTask {
+        [SerializeField, Required] private Dialogue m_Dialogue;
+        [LabelText("[?] Track Only When Running"), Tooltip("If this is true then the task will only update while the task is running.")]
+        [SerializeField] private bool m_TrackOnlyWhenRunning = true;
+
+        private ModuleTaskState m_CurrentState = ModuleTaskState.Running;
+
+        private void OnEnable() {
+            DialogueManager.DialogueEnded += OnDialogueEnded;
+        }
+
+        private void OnDisable() {
+            DialogueManager.DialogueEnded -= OnDialogueEnded;
+        }
+
+        protected override void OnModuleTaskStarted() {
+            if (m_TrackOnlyWhenRunning) {
+                m_CurrentState = ModuleTaskState.Running;
+            }
+        }
+
+        protected override ModuleTaskState ExecuteModuleTask() {
+            return m_CurrentState;
+        }
+
+        private void OnDialogueEnded(Dialogue dialogue, bool completed) {
+            if (m_TrackOnlyWhenRunning && !Started) {
+                return;
+            }
+
+            if (dialogue != m_Dialogue) {
+                return;
+            }
+
+            m_CurrentState = completed ? ModuleTaskState.Successful : ModuleTaskState.Failure;
+        }
+    }
+}

--- a/ORST/Assets/Scripts/Core/ModuleTasks/GeneralTasks/CompleteDialogueTask.cs.meta
+++ b/ORST/Assets/Scripts/Core/ModuleTasks/GeneralTasks/CompleteDialogueTask.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 50ba23d7085c477188924e033ba43fb9
+timeCreated: 1667900551

--- a/ORST/Assets/Scripts/Core/ModuleTasks/GeneralTasks/InitiateDialogueTask.cs
+++ b/ORST/Assets/Scripts/Core/ModuleTasks/GeneralTasks/InitiateDialogueTask.cs
@@ -1,0 +1,41 @@
+﻿using ORST.Core.Dialogues;
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+namespace ORST.Core.ModuleTasks {
+    public class InitiateDialogueTask : ModuleTask {
+        [SerializeField, Required] private Dialogue m_Dialogue;
+        [LabelText("[?] Track Only When Running"), Tooltip("If this is true then the task will only update while the task is running.")]
+        [SerializeField] private bool m_TrackOnlyWhenRunning = true;
+
+        private bool m_Completed;
+
+        private void OnEnable() {
+            DialogueManager.DialogueStarted += OnDialogueStarted;
+        }
+
+        private void OnDisable() {
+            DialogueManager.DialogueStarted -= OnDialogueStarted;
+        }
+
+        protected override void OnModuleTaskStarted() {
+            if (m_TrackOnlyWhenRunning) {
+                m_Completed = false;
+            }
+        }
+
+        protected override ModuleTaskState ExecuteModuleTask() {
+            return m_Completed ? ModuleTaskState.Successful : ModuleTaskState.Running;
+        }
+
+        private void OnDialogueStarted(Dialogue dialogue) {
+            if (m_TrackOnlyWhenRunning && !Started) {
+                return;
+            }
+
+            if (dialogue == m_Dialogue) {
+                m_Completed = true;
+            }
+        }
+    }
+}

--- a/ORST/Assets/Scripts/Core/ModuleTasks/GeneralTasks/InitiateDialogueTask.cs.meta
+++ b/ORST/Assets/Scripts/Core/ModuleTasks/GeneralTasks/InitiateDialogueTask.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: af923dfa551d4f4dab2d23f19acfae85
+timeCreated: 1667899439


### PR DESCRIPTION
This PR adds scripts for two additional common tasks that the user might have to do:
* `InitiateDialogueTask` - task completes successfully when the player starts a specific dialogue
* `CompleteDialogueTask` - task completes successfully when the player **successfully** completes a dialogue. If the dialogue is cancelled/stopped before it's completed, then the task is marked as `Failed`