### PR TITLE
Implement Hand Pose interpolation

### DIFF
--- a/ORST/Assets/Oculus/Interaction/Editor/Grab/Visuals/HandPuppetEditor.cs
+++ b/ORST/Assets/Oculus/Interaction/Editor/Grab/Visuals/HandPuppetEditor.cs
@@ -39,11 +39,16 @@ namespace Oculus.Interaction.HandGrab.Visuals.Editor
             HandPuppet puppet = target as HandPuppet;
             if (GUILayout.Button("Auto-Assign Bones"))
             {
-                SkinnedMeshRenderer skinnedHand = puppet.GetComponentInChildren<SkinnedMeshRenderer>();
+                SkinnedMeshRenderer skinnedHand = puppet!.GetComponentInChildren<SkinnedMeshRenderer>();
                 if (skinnedHand != null)
                 {
                     SetPrivateValue(puppet, "_jointMaps", AutoAsignBones(skinnedHand));
                 }
+            }
+
+            if (GUILayout.Button("Reset JointsCache"))
+            {
+                puppet!.ResetJointsCache();
             }
         }
 

--- a/ORST/Assets/Oculus/Interaction/Runtime/Scripts/Grab/Visuals/HandPuppet.cs
+++ b/ORST/Assets/Oculus/Interaction/Runtime/Scripts/Grab/Visuals/HandPuppet.cs
@@ -77,6 +77,11 @@ namespace Oculus.Interaction.HandGrab.Visuals
             }
         }
 
+        public void ResetJointsCache()
+        {
+            _jointsCache = null;
+        }
+
         /// <summary>
         /// Rotates all the joints in this puppet to the desired pose.
         /// </summary>

--- a/ORST/Assets/Scripts/Core/Editor/MenuItems.cs
+++ b/ORST/Assets/Scripts/Core/Editor/MenuItems.cs
@@ -1,0 +1,45 @@
+﻿using Oculus.Interaction.HandGrab.Visuals;
+using Oculus.Interaction.Input;
+using ORST.Core.Interactions;
+using UnityEditor;
+using UnityEngine;
+
+namespace ORST.Core.Editor {
+    public static class MenuItems {
+        [MenuItem("CONTEXT/HandPuppet/Save Hand Pose (Left)")]
+        private static void HandPuppet_SaveHandPoseLeft(MenuCommand command) {
+            if (command.context is not HandPuppet handPuppet) {
+                return;
+            }
+
+            HandPuppet_SaveHandPose(handPuppet, Handedness.Left);
+        }
+
+        [MenuItem("CONTEXT/HandPuppet/Save Hand Pose (Right)")]
+        private static void HandPuppet_SaveHandPoseRight(MenuCommand command) {
+            if (command.context is not HandPuppet handPuppet) {
+                return;
+            }
+
+            HandPuppet_SaveHandPose(handPuppet, Handedness.Right);
+        }
+
+        private static void HandPuppet_SaveHandPose(HandPuppet handPuppet, Handedness handedness) {
+            string path = EditorUtility.SaveFilePanel("Save Hand Pose Data", "", "HandPoseData", "asset");
+            if (string.IsNullOrEmpty(path)) {
+                return;
+            }
+
+            string relativePath = path.Replace(Application.dataPath, "Assets");
+            HandPoseData handPoseData = ScriptableObject.CreateInstance<HandPoseData>();
+            handPoseData.InitializeFromJointCollection(new JointCollection(handPuppet.JointMaps), handedness);
+            AssetDatabase.CreateAsset(handPoseData, relativePath);
+            AssetDatabase.SaveAssets();
+
+            EditorApplication.delayCall += () => {
+                Selection.activeObject = handPoseData;
+                EditorGUIUtility.PingObject(handPoseData);
+            };
+        }
+    }
+}

--- a/ORST/Assets/Scripts/Core/Editor/MenuItems.cs.meta
+++ b/ORST/Assets/Scripts/Core/Editor/MenuItems.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0c5d0ffecf8445f1ab7a1cc47d203208
+timeCreated: 1667905631

--- a/ORST/Assets/Scripts/Core/Editor/ORST.Core.Editor.asmdef
+++ b/ORST/Assets/Scripts/Core/Editor/ORST.Core.Editor.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "ORST.Core.Editor",
     "references": [
         "GUID:02d8cb16e809bde4b95b9443f1ce3b6a",
-        "GUID:35a90187a9ea2e347a95e4b1f3aede41"
+        "GUID:35a90187a9ea2e347a95e4b1f3aede41",
+        "GUID:2a230cb87a1d3ba4a98bdc0ddae76e6c"
     ],
     "includePlatforms": [
         "Editor"

--- a/ORST/Assets/Scripts/Core/Interactions/HandPose.meta
+++ b/ORST/Assets/Scripts/Core/Interactions/HandPose.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cb6ca4aa552546ed9b2fcd4f16fa5703
+timeCreated: 1667908890

--- a/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseData.cs
+++ b/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseData.cs
@@ -1,0 +1,36 @@
+﻿using Oculus.Interaction.HandGrab;
+using Oculus.Interaction.HandGrab.Visuals;
+using Oculus.Interaction.Input;
+using Sirenix.OdinInspector;
+using Sirenix.Serialization;
+using UnityEngine;
+
+namespace ORST.Core.Interactions {
+    public class HandPoseData : SerializedScriptableObject {
+        [OdinSerialize, ReadOnly] private HandPose m_HandPose;
+        [OdinSerialize, ReadOnly] private Vector3[] m_JointPositions;
+
+        public HandPose HandPose => m_HandPose;
+
+        public Pose? this[HandJointId jointId] {
+            get {
+                int offset = (int)FingersMetadata.HAND_JOINT_IDS[0];
+                int index = (int)jointId - offset;
+                if (index < 0 || index >= m_JointPositions.Length) {
+                    return null;
+                }
+
+                return new Pose(m_JointPositions[index], m_HandPose.JointRotations[index]);
+            }
+        }
+
+        public void InitializeFromJointCollection(JointCollection jointCollection, Handedness handedness) {
+            m_HandPose = new HandPose(handedness);
+            m_JointPositions = new Vector3[FingersMetadata.HAND_JOINT_IDS.Length];
+            for (int i = 0; i < FingersMetadata.HAND_JOINT_IDS.Length; i++) {
+                m_HandPose.JointRotations[i] = jointCollection[i]?.TrackedRotation ?? Quaternion.identity;
+                m_JointPositions[i] = jointCollection[i]?.transform.localPosition ?? Vector3.zero;
+            }
+        }
+    }
+}

--- a/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseData.cs.meta
+++ b/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseData.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d8c3389349cb4574976f8fbc8e48cc1b
+timeCreated: 1667905850

--- a/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseInterpolator.cs
+++ b/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseInterpolator.cs
@@ -1,0 +1,9 @@
+﻿using Oculus.Interaction.HandGrab;
+
+namespace ORST.Core.Interactions {
+    public static class HandPoseInterpolator {
+        public static void Interpolate(HandPoseData handPoseA, HandPoseData handPoseB, HandPose interpolatedPose, float t) {
+            HandPose.Lerp(handPoseA.HandPose, handPoseB.HandPose, t, ref interpolatedPose);
+        }
+    }
+}

--- a/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseInterpolator.cs.meta
+++ b/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseInterpolator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b2a50856acc444e5b63d35781ef0c25d
+timeCreated: 1667908890

--- a/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseInterpolatorVisualizer.cs
+++ b/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseInterpolatorVisualizer.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Oculus.Interaction.HandGrab;
+using Oculus.Interaction.HandGrab.Visuals;
+using ORST.Foundation.Core;
+using Sirenix.OdinInspector;
+using UnityEngine;
+
+namespace ORST.Core.Interactions {
+    [ExecuteAlways]
+    public class HandPoseInterpolatorVisualizer : BaseMonoBehaviour {
+        [SerializeField, Required] private HandPoseData m_HandPoseA;
+        [SerializeField, Required] private HandPoseData m_HandPoseB;
+        [SerializeField, Required] private HandPuppet m_Puppet;
+        [Space]
+        [SerializeField, Range(0.0f, 1.0f), OnValueChanged(nameof(OnTChanged))] private float m_T;
+
+        private HandPose m_InterpolatedPose;
+
+        private void Update() {
+            Interpolate();
+        }
+
+        private void Interpolate() {
+            HandPoseInterpolator.Interpolate(m_HandPoseA, m_HandPoseB, m_InterpolatedPose ??= new HandPose(m_HandPoseA.HandPose), m_T);
+            m_Puppet.SetJointRotations(m_InterpolatedPose.JointRotations);
+        }
+
+        private void OnTChanged() {
+            if (m_HandPoseA == null || m_HandPoseB == null || m_Puppet == null) {
+                return;
+            }
+
+            Interpolate();
+        }
+    }
+}

--- a/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseInterpolatorVisualizer.cs.meta
+++ b/ORST/Assets/Scripts/Core/Interactions/HandPose/HandPoseInterpolatorVisualizer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3f7ad193a8eb4a04a415b5f4356adafe
+timeCreated: 1667909016

--- a/ORST/Assets/_Assets/Poses.meta
+++ b/ORST/Assets/_Assets/Poses.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bed488cb47a6a8a48bb47732595af566
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ORST/Assets/_Assets/Poses/Pose_Pinch_L.asset
+++ b/ORST/Assets/_Assets/Poses/Pose_Pinch_L.asset
@@ -1,0 +1,644 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8c3389349cb4574976f8fbc8e48cc1b, type: 3}
+  m_Name: Pose_Pinch_L
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: m_HandPose
+      Entry: 7
+      Data: 0|Oculus.Interaction.HandGrab.HandPose, Oculus.Interaction
+    - Name: _handedness
+      Entry: 3
+      Data: 0
+    - Name: _fingersFreedom
+      Entry: 7
+      Data: 1|Oculus.Interaction.Input.JointFreedom[], Oculus.Interaction
+    - Name: 
+      Entry: 12
+      Data: 5
+    - Name: 
+      Entry: 3
+      Data: 2
+    - Name: 
+      Entry: 3
+      Data: 2
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 3
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: _jointRotations
+      Entry: 7
+      Data: 2|UnityEngine.Quaternion[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 12
+      Data: 17
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.375387371
+    - Name: 
+      Entry: 4
+      Data: -0.4245841
+    - Name: 
+      Entry: 4
+      Data: 0.007778898
+    - Name: 
+      Entry: 4
+      Data: 0.8238642
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.3054245
+    - Name: 
+      Entry: 4
+      Data: -0.115501322
+    - Name: 
+      Entry: 4
+      Data: -0.322341442
+    - Name: 
+      Entry: 4
+      Data: 0.888521969
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08310853
+    - Name: 
+      Entry: 4
+      Data: 0.06335884
+    - Name: 
+      Entry: 4
+      Data: -0.07957443
+    - Name: 
+      Entry: 4
+      Data: 0.99133575
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0796122253
+    - Name: 
+      Entry: 4
+      Data: -0.0518409535
+    - Name: 
+      Entry: 4
+      Data: -0.09936826
+    - Name: 
+      Entry: 4
+      Data: 0.9905051
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0545471
+    - Name: 
+      Entry: 4
+      Data: -0.01701542
+    - Name: 
+      Entry: 4
+      Data: -0.4694428
+    - Name: 
+      Entry: 4
+      Data: 0.8811121
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0259378459
+    - Name: 
+      Entry: 4
+      Data: -0.00276603922
+    - Name: 
+      Entry: 4
+      Data: -0.366287082
+    - Name: 
+      Entry: 4
+      Data: 0.9301362
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0168651324
+    - Name: 
+      Entry: 4
+      Data: 0.0242213942
+    - Name: 
+      Entry: 4
+      Data: -0.101804852
+    - Name: 
+      Entry: 4
+      Data: 0.9943664
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0224427953
+    - Name: 
+      Entry: 4
+      Data: 0.0253421031
+    - Name: 
+      Entry: 4
+      Data: -0.54684
+    - Name: 
+      Entry: 4
+      Data: 0.8365525
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0121645648
+    - Name: 
+      Entry: 4
+      Data: -0.00579368975
+    - Name: 
+      Entry: 4
+      Data: -0.7649409
+    - Name: 
+      Entry: 4
+      Data: 0.643959463
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08720313
+    - Name: 
+      Entry: 4
+      Data: -0.0216591284
+    - Name: 
+      Entry: 4
+      Data: -0.506869733
+    - Name: 
+      Entry: 4
+      Data: 0.857327
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0956106
+    - Name: 
+      Entry: 4
+      Data: 0.0611655042
+    - Name: 
+      Entry: 4
+      Data: -0.560798466
+    - Name: 
+      Entry: 4
+      Data: 0.8201357
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0412705466
+    - Name: 
+      Entry: 4
+      Data: -0.0225725211
+    - Name: 
+      Entry: 4
+      Data: -0.7339317
+    - Name: 
+      Entry: 4
+      Data: 0.6775924
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0278068949
+    - Name: 
+      Entry: 4
+      Data: 0.0276008472
+    - Name: 
+      Entry: 4
+      Data: 0.5073111
+    - Name: 
+      Entry: 4
+      Data: -0.860872
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.207035869
+    - Name: 
+      Entry: 4
+      Data: 0.140342832
+    - Name: 
+      Entry: 4
+      Data: -0.01831182
+    - Name: 
+      Entry: 4
+      Data: 0.968041658
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.05200825
+    - Name: 
+      Entry: 4
+      Data: -0.0526982546
+    - Name: 
+      Entry: 4
+      Data: 0.5055469
+    - Name: 
+      Entry: 4
+      Data: -0.859616458
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0916696638
+    - Name: 
+      Entry: 4
+      Data: -0.002026394
+    - Name: 
+      Entry: 4
+      Data: -0.7582235
+    - Name: 
+      Entry: 4
+      Data: 0.6455152
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.00247461721
+    - Name: 
+      Entry: 4
+      Data: 0.04099303
+    - Name: 
+      Entry: 4
+      Data: 0.539901733
+    - Name: 
+      Entry: 4
+      Data: -0.8407256
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: m_JointPositions
+      Entry: 7
+      Data: 3|UnityEngine.Vector3[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 12
+      Data: 17
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0200693011
+    - Name: 
+      Entry: 4
+      Data: 0.0115540987
+    - Name: 
+      Entry: 4
+      Data: -0.0104965195
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.024852559
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 4
+      Data: 1.05471186E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.03251291
+    - Name: 
+      Entry: 4
+      Data: 1.7763568E-17
+    - Name: 
+      Entry: 4
+      Data: -2.6090241E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.03379309
+    - Name: 
+      Entry: 4
+      Data: -1.3322676E-17
+    - Name: 
+      Entry: 4
+      Data: 3.4416914E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.09599624
+    - Name: 
+      Entry: 4
+      Data: 0.00731645431
+    - Name: 
+      Entry: 4
+      Data: -0.02355068
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0379273
+    - Name: 
+      Entry: 4
+      Data: -2.220446E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.024303643
+    - Name: 
+      Entry: 4
+      Data: 3.0531133E-18
+    - Name: 
+      Entry: 4
+      Data: 4.440892E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0956466049
+    - Name: 
+      Entry: 4
+      Data: 0.00254315464
+    - Name: 
+      Entry: 4
+      Data: -0.00172590546
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.04292699
+    - Name: 
+      Entry: 4
+      Data: 0
+    - Name: 
+      Entry: 4
+      Data: 0
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0275495835
+    - Name: 
+      Entry: 4
+      Data: 0
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08869379
+    - Name: 
+      Entry: 4
+      Data: 0.006529307
+    - Name: 
+      Entry: 4
+      Data: 0.0174652413
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0389961
+    - Name: 
+      Entry: 4
+      Data: 7.771561E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0265733972
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: 0
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0340735577
+    - Name: 
+      Entry: 4
+      Data: 0.009419835
+    - Name: 
+      Entry: 4
+      Data: 0.0229985733
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.04565054
+    - Name: 
+      Entry: 4
+      Data: 9.982332E-07
+    - Name: 
+      Entry: 4
+      Data: -2.19402546E-06
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.030720409
+    - Name: 
+      Entry: 4
+      Data: -3.330669E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0203113835
+    - Name: 
+      Entry: 4
+      Data: 6.661338E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/ORST/Assets/_Assets/Poses/Pose_Pinch_L.asset.meta
+++ b/ORST/Assets/_Assets/Poses/Pose_Pinch_L.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4611418a8601e0c49a21eed0338342d6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ORST/Assets/_Assets/Poses/Pose_Pinch_R.asset
+++ b/ORST/Assets/_Assets/Poses/Pose_Pinch_R.asset
@@ -1,0 +1,644 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8c3389349cb4574976f8fbc8e48cc1b, type: 3}
+  m_Name: Pose_Pinch_R
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: m_HandPose
+      Entry: 7
+      Data: 0|Oculus.Interaction.HandGrab.HandPose, Oculus.Interaction
+    - Name: _handedness
+      Entry: 3
+      Data: 1
+    - Name: _fingersFreedom
+      Entry: 7
+      Data: 1|Oculus.Interaction.Input.JointFreedom[], Oculus.Interaction
+    - Name: 
+      Entry: 12
+      Data: 5
+    - Name: 
+      Entry: 3
+      Data: 2
+    - Name: 
+      Entry: 3
+      Data: 2
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 3
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: _jointRotations
+      Entry: 7
+      Data: 2|UnityEngine.Quaternion[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 12
+      Data: 17
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.375387371
+    - Name: 
+      Entry: 4
+      Data: -0.4245841
+    - Name: 
+      Entry: 4
+      Data: 0.007778898
+    - Name: 
+      Entry: 4
+      Data: 0.8238642
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.3054245
+    - Name: 
+      Entry: 4
+      Data: -0.115501322
+    - Name: 
+      Entry: 4
+      Data: -0.322341442
+    - Name: 
+      Entry: 4
+      Data: 0.888521969
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08310853
+    - Name: 
+      Entry: 4
+      Data: 0.06335884
+    - Name: 
+      Entry: 4
+      Data: -0.07957443
+    - Name: 
+      Entry: 4
+      Data: 0.99133575
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0796122253
+    - Name: 
+      Entry: 4
+      Data: -0.0518409535
+    - Name: 
+      Entry: 4
+      Data: -0.09936826
+    - Name: 
+      Entry: 4
+      Data: 0.9905051
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0545471
+    - Name: 
+      Entry: 4
+      Data: -0.01701542
+    - Name: 
+      Entry: 4
+      Data: -0.4694428
+    - Name: 
+      Entry: 4
+      Data: 0.8811121
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0259378459
+    - Name: 
+      Entry: 4
+      Data: -0.00276603922
+    - Name: 
+      Entry: 4
+      Data: -0.366287082
+    - Name: 
+      Entry: 4
+      Data: 0.9301362
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0168651324
+    - Name: 
+      Entry: 4
+      Data: 0.0242213942
+    - Name: 
+      Entry: 4
+      Data: -0.101804852
+    - Name: 
+      Entry: 4
+      Data: 0.9943664
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0224427953
+    - Name: 
+      Entry: 4
+      Data: 0.0253421031
+    - Name: 
+      Entry: 4
+      Data: -0.54684
+    - Name: 
+      Entry: 4
+      Data: 0.8365525
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0121645648
+    - Name: 
+      Entry: 4
+      Data: -0.00579368975
+    - Name: 
+      Entry: 4
+      Data: -0.7649409
+    - Name: 
+      Entry: 4
+      Data: 0.643959463
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08720313
+    - Name: 
+      Entry: 4
+      Data: -0.0216591284
+    - Name: 
+      Entry: 4
+      Data: -0.506869733
+    - Name: 
+      Entry: 4
+      Data: 0.857327
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0956106
+    - Name: 
+      Entry: 4
+      Data: 0.0611655042
+    - Name: 
+      Entry: 4
+      Data: -0.560798466
+    - Name: 
+      Entry: 4
+      Data: 0.8201357
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0412705466
+    - Name: 
+      Entry: 4
+      Data: -0.0225725211
+    - Name: 
+      Entry: 4
+      Data: -0.7339317
+    - Name: 
+      Entry: 4
+      Data: 0.6775924
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0278068949
+    - Name: 
+      Entry: 4
+      Data: 0.0276008472
+    - Name: 
+      Entry: 4
+      Data: 0.5073111
+    - Name: 
+      Entry: 4
+      Data: -0.860872
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.207035869
+    - Name: 
+      Entry: 4
+      Data: 0.140342832
+    - Name: 
+      Entry: 4
+      Data: -0.01831182
+    - Name: 
+      Entry: 4
+      Data: 0.968041658
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.05200825
+    - Name: 
+      Entry: 4
+      Data: -0.0526982546
+    - Name: 
+      Entry: 4
+      Data: 0.5055469
+    - Name: 
+      Entry: 4
+      Data: -0.859616458
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0916696638
+    - Name: 
+      Entry: 4
+      Data: -0.002026394
+    - Name: 
+      Entry: 4
+      Data: -0.7582235
+    - Name: 
+      Entry: 4
+      Data: 0.6455152
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.00247461721
+    - Name: 
+      Entry: 4
+      Data: 0.04099303
+    - Name: 
+      Entry: 4
+      Data: 0.539901733
+    - Name: 
+      Entry: 4
+      Data: -0.8407256
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: m_JointPositions
+      Entry: 7
+      Data: 3|UnityEngine.Vector3[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 12
+      Data: 17
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0200693011
+    - Name: 
+      Entry: 4
+      Data: -0.0115540987
+    - Name: 
+      Entry: 4
+      Data: 0.0104965195
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.024852559
+    - Name: 
+      Entry: 4
+      Data: 4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: -1.16573414E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.03251291
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: 3.21964668E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.03379309
+    - Name: 
+      Entry: 4
+      Data: 1.3322676E-17
+    - Name: 
+      Entry: 4
+      Data: -1.66533444E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.09599624
+    - Name: 
+      Entry: 4
+      Data: -0.00731645431
+    - Name: 
+      Entry: 4
+      Data: 0.02355068
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0379273
+    - Name: 
+      Entry: 4
+      Data: 3.330669E-18
+    - Name: 
+      Entry: 4
+      Data: 1.3322676E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.024303643
+    - Name: 
+      Entry: 4
+      Data: -5.2735593E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0956466049
+    - Name: 
+      Entry: 4
+      Data: -0.00254315441
+    - Name: 
+      Entry: 4
+      Data: 0.00172590546
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.04292699
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: 4.440892E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0275495835
+    - Name: 
+      Entry: 4
+      Data: 1.110223E-18
+    - Name: 
+      Entry: 4
+      Data: 8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.08869379
+    - Name: 
+      Entry: 4
+      Data: -0.006529307
+    - Name: 
+      Entry: 4
+      Data: -0.0174652413
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0389961
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 4
+      Data: 8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0265733972
+    - Name: 
+      Entry: 4
+      Data: 4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0340735577
+    - Name: 
+      Entry: 4
+      Data: -0.009419835
+    - Name: 
+      Entry: 4
+      Data: -0.0229985733
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.04565054
+    - Name: 
+      Entry: 4
+      Data: -9.982332E-07
+    - Name: 
+      Entry: 4
+      Data: 2.19402546E-06
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.030720409
+    - Name: 
+      Entry: 4
+      Data: 1.110223E-18
+    - Name: 
+      Entry: 4
+      Data: -3.77475832E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0203113835
+    - Name: 
+      Entry: 4
+      Data: -6.661338E-18
+    - Name: 
+      Entry: 4
+      Data: 1.7763568E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/ORST/Assets/_Assets/Poses/Pose_Pinch_R.asset.meta
+++ b/ORST/Assets/_Assets/Poses/Pose_Pinch_R.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5cb995503ec261244bb978148efa31fd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ORST/Assets/_Assets/Poses/Pose_Point_L.asset
+++ b/ORST/Assets/_Assets/Poses/Pose_Point_L.asset
@@ -1,0 +1,644 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8c3389349cb4574976f8fbc8e48cc1b, type: 3}
+  m_Name: Pose_Point_L
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: m_HandPose
+      Entry: 7
+      Data: 0|Oculus.Interaction.HandGrab.HandPose, Oculus.Interaction
+    - Name: _handedness
+      Entry: 3
+      Data: 0
+    - Name: _fingersFreedom
+      Entry: 7
+      Data: 1|Oculus.Interaction.Input.JointFreedom[], Oculus.Interaction
+    - Name: 
+      Entry: 12
+      Data: 5
+    - Name: 
+      Entry: 3
+      Data: 2
+    - Name: 
+      Entry: 3
+      Data: 2
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 3
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: _jointRotations
+      Entry: 7
+      Data: 2|UnityEngine.Quaternion[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 12
+      Data: 17
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.375387371
+    - Name: 
+      Entry: 4
+      Data: -0.4245841
+    - Name: 
+      Entry: 4
+      Data: 0.007778898
+    - Name: 
+      Entry: 4
+      Data: 0.8238642
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.291469336
+    - Name: 
+      Entry: 4
+      Data: -0.140509456
+    - Name: 
+      Entry: 4
+      Data: -0.304171652
+    - Name: 
+      Entry: 4
+      Data: 0.895981252
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08318525
+    - Name: 
+      Entry: 4
+      Data: 0.06530857
+    - Name: 
+      Entry: 4
+      Data: -0.057455454
+    - Name: 
+      Entry: 4
+      Data: 0.9927305
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0793632045
+    - Name: 
+      Entry: 4
+      Data: -0.0511428267
+    - Name: 
+      Entry: 4
+      Data: -0.107244916
+    - Name: 
+      Entry: 4
+      Data: 0.989739537
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.02976254
+    - Name: 
+      Entry: 4
+      Data: -0.03860152
+    - Name: 
+      Entry: 4
+      Data: 0.246615976
+    - Name: 
+      Entry: 4
+      Data: -0.967886746
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0262719188
+    - Name: 
+      Entry: 4
+      Data: -9.052735E-05
+    - Name: 
+      Entry: 4
+      Data: -0.271652669
+    - Name: 
+      Entry: 4
+      Data: 0.9620367
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.01662625
+    - Name: 
+      Entry: 4
+      Data: 0.02538699
+    - Name: 
+      Entry: 4
+      Data: -0.0380259156
+    - Name: 
+      Entry: 4
+      Data: 0.9988159
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0372821577
+    - Name: 
+      Entry: 4
+      Data: 0.0512194335
+    - Name: 
+      Entry: 4
+      Data: -0.540445149
+    - Name: 
+      Entry: 4
+      Data: 0.8389908
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0123074055
+    - Name: 
+      Entry: 4
+      Data: -0.00543488935
+    - Name: 
+      Entry: 4
+      Data: -0.74285984
+    - Name: 
+      Entry: 4
+      Data: 0.6693119
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08432786
+    - Name: 
+      Entry: 4
+      Data: -0.0199346114
+    - Name: 
+      Entry: 4
+      Data: -0.467656732
+    - Name: 
+      Entry: 4
+      Data: 0.87965256
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.10538134
+    - Name: 
+      Entry: 4
+      Data: 0.06816966
+    - Name: 
+      Entry: 4
+      Data: -0.5948155
+    - Name: 
+      Entry: 4
+      Data: 0.794003844
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.04158234
+    - Name: 
+      Entry: 4
+      Data: -0.0213458315
+    - Name: 
+      Entry: 4
+      Data: -0.700406
+    - Name: 
+      Entry: 4
+      Data: 0.7122125
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0260381233
+    - Name: 
+      Entry: 4
+      Data: 0.0280699283
+    - Name: 
+      Entry: 4
+      Data: 0.4673857
+    - Name: 
+      Entry: 4
+      Data: -0.88322407
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.207035869
+    - Name: 
+      Entry: 4
+      Data: 0.140342817
+    - Name: 
+      Entry: 4
+      Data: -0.0183118246
+    - Name: 
+      Entry: 4
+      Data: 0.968041658
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0376318768
+    - Name: 
+      Entry: 4
+      Data: -0.06520599
+    - Name: 
+      Entry: 4
+      Data: 0.603466
+    - Name: 
+      Entry: 4
+      Data: -0.79382664
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08933254
+    - Name: 
+      Entry: 4
+      Data: 0.00236998126
+    - Name: 
+      Entry: 4
+      Data: -0.7066915
+    - Name: 
+      Entry: 4
+      Data: 0.7018556
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.00232582726
+    - Name: 
+      Entry: 4
+      Data: 0.0424895063
+    - Name: 
+      Entry: 4
+      Data: 0.49051103
+    - Name: 
+      Entry: 4
+      Data: -0.870395362
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: m_JointPositions
+      Entry: 7
+      Data: 3|UnityEngine.Vector3[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 12
+      Data: 17
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0200693011
+    - Name: 
+      Entry: 4
+      Data: 0.0115540987
+    - Name: 
+      Entry: 4
+      Data: -0.0104965195
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.024852559
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 4
+      Data: 1.05471186E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.03251291
+    - Name: 
+      Entry: 4
+      Data: 1.7763568E-17
+    - Name: 
+      Entry: 4
+      Data: -2.6090241E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.03379309
+    - Name: 
+      Entry: 4
+      Data: -1.3322676E-17
+    - Name: 
+      Entry: 4
+      Data: 3.4416914E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.09599624
+    - Name: 
+      Entry: 4
+      Data: 0.00731645431
+    - Name: 
+      Entry: 4
+      Data: -0.02355068
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0379273
+    - Name: 
+      Entry: 4
+      Data: -2.220446E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.024303643
+    - Name: 
+      Entry: 4
+      Data: 3.0531133E-18
+    - Name: 
+      Entry: 4
+      Data: 4.440892E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0956466049
+    - Name: 
+      Entry: 4
+      Data: 0.00254315464
+    - Name: 
+      Entry: 4
+      Data: -0.00172590546
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.04292699
+    - Name: 
+      Entry: 4
+      Data: 0
+    - Name: 
+      Entry: 4
+      Data: 0
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0275495835
+    - Name: 
+      Entry: 4
+      Data: 0
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08869379
+    - Name: 
+      Entry: 4
+      Data: 0.006529307
+    - Name: 
+      Entry: 4
+      Data: 0.0174652413
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0389961
+    - Name: 
+      Entry: 4
+      Data: 7.771561E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0265733972
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: 0
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0340735577
+    - Name: 
+      Entry: 4
+      Data: 0.009419835
+    - Name: 
+      Entry: 4
+      Data: 0.0229985733
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.04565054
+    - Name: 
+      Entry: 4
+      Data: 9.982332E-07
+    - Name: 
+      Entry: 4
+      Data: -2.19402546E-06
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.030720409
+    - Name: 
+      Entry: 4
+      Data: -3.330669E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0203113835
+    - Name: 
+      Entry: 4
+      Data: 6.661338E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/ORST/Assets/_Assets/Poses/Pose_Point_L.asset.meta
+++ b/ORST/Assets/_Assets/Poses/Pose_Point_L.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c53561f1a816c9b4db533f09a05c7b60
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ORST/Assets/_Assets/Poses/Pose_Point_R.asset
+++ b/ORST/Assets/_Assets/Poses/Pose_Point_R.asset
@@ -1,0 +1,644 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8c3389349cb4574976f8fbc8e48cc1b, type: 3}
+  m_Name: Pose_Point_R
+  m_EditorClassIdentifier: 
+  serializationData:
+    SerializedFormat: 2
+    SerializedBytes: 
+    ReferencedUnityObjects: []
+    SerializedBytesString: 
+    Prefab: {fileID: 0}
+    PrefabModificationsReferencedUnityObjects: []
+    PrefabModifications: []
+    SerializationNodes:
+    - Name: m_HandPose
+      Entry: 7
+      Data: 0|Oculus.Interaction.HandGrab.HandPose, Oculus.Interaction
+    - Name: _handedness
+      Entry: 3
+      Data: 1
+    - Name: _fingersFreedom
+      Entry: 7
+      Data: 1|Oculus.Interaction.Input.JointFreedom[], Oculus.Interaction
+    - Name: 
+      Entry: 12
+      Data: 5
+    - Name: 
+      Entry: 3
+      Data: 2
+    - Name: 
+      Entry: 3
+      Data: 2
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 3
+      Data: 1
+    - Name: 
+      Entry: 3
+      Data: 0
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: _jointRotations
+      Entry: 7
+      Data: 2|UnityEngine.Quaternion[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 12
+      Data: 17
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.375387371
+    - Name: 
+      Entry: 4
+      Data: -0.4245841
+    - Name: 
+      Entry: 4
+      Data: 0.007778898
+    - Name: 
+      Entry: 4
+      Data: 0.8238642
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.291469336
+    - Name: 
+      Entry: 4
+      Data: -0.140509456
+    - Name: 
+      Entry: 4
+      Data: -0.304171652
+    - Name: 
+      Entry: 4
+      Data: 0.895981252
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08318525
+    - Name: 
+      Entry: 4
+      Data: 0.06530857
+    - Name: 
+      Entry: 4
+      Data: -0.057455454
+    - Name: 
+      Entry: 4
+      Data: 0.9927305
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0793632045
+    - Name: 
+      Entry: 4
+      Data: -0.0511428267
+    - Name: 
+      Entry: 4
+      Data: -0.107244916
+    - Name: 
+      Entry: 4
+      Data: 0.989739537
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.02976254
+    - Name: 
+      Entry: 4
+      Data: -0.03860152
+    - Name: 
+      Entry: 4
+      Data: 0.246615976
+    - Name: 
+      Entry: 4
+      Data: -0.967886746
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0262719188
+    - Name: 
+      Entry: 4
+      Data: -9.052735E-05
+    - Name: 
+      Entry: 4
+      Data: -0.271652669
+    - Name: 
+      Entry: 4
+      Data: 0.9620367
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.01662625
+    - Name: 
+      Entry: 4
+      Data: 0.02538699
+    - Name: 
+      Entry: 4
+      Data: -0.0380259156
+    - Name: 
+      Entry: 4
+      Data: 0.9988159
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0372821577
+    - Name: 
+      Entry: 4
+      Data: 0.0512194335
+    - Name: 
+      Entry: 4
+      Data: -0.540445149
+    - Name: 
+      Entry: 4
+      Data: 0.8389908
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0123074055
+    - Name: 
+      Entry: 4
+      Data: -0.00543488935
+    - Name: 
+      Entry: 4
+      Data: -0.74285984
+    - Name: 
+      Entry: 4
+      Data: 0.6693119
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08432786
+    - Name: 
+      Entry: 4
+      Data: -0.0199346114
+    - Name: 
+      Entry: 4
+      Data: -0.467656732
+    - Name: 
+      Entry: 4
+      Data: 0.87965256
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.10538134
+    - Name: 
+      Entry: 4
+      Data: 0.06816966
+    - Name: 
+      Entry: 4
+      Data: -0.5948155
+    - Name: 
+      Entry: 4
+      Data: 0.794003844
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.04158234
+    - Name: 
+      Entry: 4
+      Data: -0.0213458315
+    - Name: 
+      Entry: 4
+      Data: -0.700406
+    - Name: 
+      Entry: 4
+      Data: 0.7122125
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0260381233
+    - Name: 
+      Entry: 4
+      Data: 0.0280699283
+    - Name: 
+      Entry: 4
+      Data: 0.4673857
+    - Name: 
+      Entry: 4
+      Data: -0.88322407
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.207035869
+    - Name: 
+      Entry: 4
+      Data: 0.140342817
+    - Name: 
+      Entry: 4
+      Data: -0.0183118246
+    - Name: 
+      Entry: 4
+      Data: 0.968041658
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.0376318768
+    - Name: 
+      Entry: 4
+      Data: -0.06520599
+    - Name: 
+      Entry: 4
+      Data: 0.603466
+    - Name: 
+      Entry: 4
+      Data: -0.79382664
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.08933254
+    - Name: 
+      Entry: 4
+      Data: 0.00236998126
+    - Name: 
+      Entry: 4
+      Data: -0.7066915
+    - Name: 
+      Entry: 4
+      Data: 0.7018556
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Quaternion, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: -0.00232582726
+    - Name: 
+      Entry: 4
+      Data: 0.0424895063
+    - Name: 
+      Entry: 4
+      Data: 0.49051103
+    - Name: 
+      Entry: 4
+      Data: -0.870395362
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: m_JointPositions
+      Entry: 7
+      Data: 3|UnityEngine.Vector3[], UnityEngine.CoreModule
+    - Name: 
+      Entry: 12
+      Data: 17
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0200693011
+    - Name: 
+      Entry: 4
+      Data: -0.0115540987
+    - Name: 
+      Entry: 4
+      Data: 0.0104965195
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.024852559
+    - Name: 
+      Entry: 4
+      Data: 4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: -1.16573414E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.03251291
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: 3.21964668E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.03379309
+    - Name: 
+      Entry: 4
+      Data: 1.3322676E-17
+    - Name: 
+      Entry: 4
+      Data: -1.66533444E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.09599624
+    - Name: 
+      Entry: 4
+      Data: -0.00731645431
+    - Name: 
+      Entry: 4
+      Data: 0.02355068
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0379273
+    - Name: 
+      Entry: 4
+      Data: 3.330669E-18
+    - Name: 
+      Entry: 4
+      Data: 1.3322676E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.024303643
+    - Name: 
+      Entry: 4
+      Data: -5.2735593E-18
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0956466049
+    - Name: 
+      Entry: 4
+      Data: -0.00254315441
+    - Name: 
+      Entry: 4
+      Data: 0.00172590546
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.04292699
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: 4.440892E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0275495835
+    - Name: 
+      Entry: 4
+      Data: 1.110223E-18
+    - Name: 
+      Entry: 4
+      Data: 8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.08869379
+    - Name: 
+      Entry: 4
+      Data: -0.006529307
+    - Name: 
+      Entry: 4
+      Data: -0.0174652413
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0389961
+    - Name: 
+      Entry: 4
+      Data: -8.881784E-18
+    - Name: 
+      Entry: 4
+      Data: 8.881784E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0265733972
+    - Name: 
+      Entry: 4
+      Data: 4.440892E-18
+    - Name: 
+      Entry: 4
+      Data: -4.440892E-18
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0340735577
+    - Name: 
+      Entry: 4
+      Data: -0.009419835
+    - Name: 
+      Entry: 4
+      Data: -0.0229985733
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.04565054
+    - Name: 
+      Entry: 4
+      Data: -9.982332E-07
+    - Name: 
+      Entry: 4
+      Data: 2.19402546E-06
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.030720409
+    - Name: 
+      Entry: 4
+      Data: 1.110223E-18
+    - Name: 
+      Entry: 4
+      Data: -3.77475832E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 7
+      Data: UnityEngine.Vector3, UnityEngine.CoreModule
+    - Name: 
+      Entry: 4
+      Data: 0.0203113835
+    - Name: 
+      Entry: 4
+      Data: -6.661338E-18
+    - Name: 
+      Entry: 4
+      Data: 1.7763568E-17
+    - Name: 
+      Entry: 8
+      Data: 
+    - Name: 
+      Entry: 13
+      Data: 
+    - Name: 
+      Entry: 8
+      Data: 

--- a/ORST/Assets/_Assets/Poses/Pose_Point_R.asset.meta
+++ b/ORST/Assets/_Assets/Poses/Pose_Point_R.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d201895489849c948a167a2fc6e291da
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ORST/ORST.Core.csproj.DotSettings
+++ b/ORST/ORST.Core.csproj.DotSettings
@@ -9,6 +9,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cscripts_005Ccore_005Cdialogues_005Cui/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cscripts_005Ccore_005Cinteractions_005Cactivestates/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cscripts_005Ccore_005Cinteractions_005Chandedness/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cscripts_005Ccore_005Cinteractions_005Chandpose/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cscripts_005Ccore_005Cinteractions_005Cinput/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cscripts_005Ccore_005Cinteractions_005Cpoketoggle/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=assets_005Cscripts_005Ccore_005Cmoduletasks_005Cgeneraltasks/@EntryIndexedValue">True</s:Boolean>

--- a/ORST/Patches/Oculus/HandPuppet.ResetJointsCache.patch
+++ b/ORST/Patches/Oculus/HandPuppet.ResetJointsCache.patch
@@ -1,0 +1,39 @@
+diff --git a/ORST/Assets/Oculus/Interaction/Editor/Grab/Visuals/HandPuppetEditor.cs b/ORST/Assets/Oculus/Interaction/Editor/Grab/Visuals/HandPuppetEditor.cs
+index c8d5ce2..58d7abf 100644
+--- a/ORST/Assets/Oculus/Interaction/Editor/Grab/Visuals/HandPuppetEditor.cs
++++ b/ORST/Assets/Oculus/Interaction/Editor/Grab/Visuals/HandPuppetEditor.cs
+@@ -39,12 +39,17 @@ public override void OnInspectorGUI()
+             HandPuppet puppet = target as HandPuppet;
+             if (GUILayout.Button("Auto-Assign Bones"))
+             {
+-                SkinnedMeshRenderer skinnedHand = puppet.GetComponentInChildren<SkinnedMeshRenderer>();
++                SkinnedMeshRenderer skinnedHand = puppet!.GetComponentInChildren<SkinnedMeshRenderer>();
+                 if (skinnedHand != null)
+                 {
+                     SetPrivateValue(puppet, "_jointMaps", AutoAsignBones(skinnedHand));
+                 }
+             }
++
++            if (GUILayout.Button("Reset JointsCache"))
++            {
++                puppet!.ResetJointsCache();
++            }
+         }
+ 
+         private List<HandJointMap> AutoAsignBones(SkinnedMeshRenderer skinnedHand)
+diff --git a/ORST/Assets/Oculus/Interaction/Runtime/Scripts/Grab/Visuals/HandPuppet.cs b/ORST/Assets/Oculus/Interaction/Runtime/Scripts/Grab/Visuals/HandPuppet.cs
+index 1404deb..58155e1 100644
+--- a/ORST/Assets/Oculus/Interaction/Runtime/Scripts/Grab/Visuals/HandPuppet.cs
++++ b/ORST/Assets/Oculus/Interaction/Runtime/Scripts/Grab/Visuals/HandPuppet.cs
+@@ -77,6 +77,11 @@ private JointCollection JointsCache
+             }
+         }
+ 
++        public void ResetJointsCache()
++        {
++            _jointsCache = null;
++        }
++
+         /// <summary>
+         /// Rotates all the joints in this puppet to the desired pose.
+         /// </summary>


### PR DESCRIPTION
This PR adds logic for interpolating between two hand poses and adds support for storing a pose from a `HandPuppet` into a Scriptable Object which can then be referenced for interpolation.

## Usage:
```csharp
HandPoseInterpolator.Interpolate(HandPoseData handPoseA, HandPoseData handPoseB, HandPose interpolatedPose, float t)
```
or, alternatively, use `HandPose.Lerp` directly:
```csharp
HandPose.Lerp(in handPoseA.HandPose, in handPoseB.HandPose, t, ref interpolatedPose)
```